### PR TITLE
Fixed an issue with how lib names containing a dot(.) are handled

### DIFF
--- a/src/lib.js
+++ b/src/lib.js
@@ -38,7 +38,7 @@ module.exports = name => {
 		version: () => 
 			new Promise((success, _) => {
 				let version = null
-				const check = haxelib(['list', info.name])
+				const check = haxelib(['list', info.name.replace(/\./g, ",")])
 				check.stdout.on('data', data => {
 					if (info.pinned) {
 						if (data.toString().indexOf(info.pinned) > -1)


### PR DESCRIPTION
As per this issue: HaxeFoundation/haxelib#323

Encountered when using: [perf.js](https://lib.haxe.org/p/perf.js/).

Tested on macOS with Haxe 3.4, should work everywhere though.